### PR TITLE
Clamping velocity and position to boundary on client and server

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,13 +253,17 @@ setInterval(function () {
 
         if (player.x > 1170) {
             player.x = 1170;
+            player.vx = 0;
         } else if (player.x < 30) {
             player.x = 30;
+            player.vx = 0;
         }
         if (player.y > 570) {
             player.y = 570;
+            player.vy = 0;
         } else if (player.y < 30) {
             player.y = 30;
+            player.vy = 0;
         }
     }
     var toSend = {};

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -280,6 +280,10 @@ function gameTick() {
             //note: I made this up originally, 0.2 was a guess and I worked backwards to figure out why it works so well -Koupah
             px = lerp(oldPlayer.x, player.x, frameTime);
             py = lerp(oldPlayer.y, player.y, frameTime);
+            if (px < 0) px = 0;
+            if (px < bw - 35) px = bw - 35;
+            if (py < 0) py = 0;
+            if (py > bh - 35) py = bh - 35;
             oldPlayer.cx = px;
             oldPlayer.cy = py;
         } else {


### PR DESCRIPTION
If there is enough lag on the client, it can possibly lerp other players out of bounds. This PR addresses that issue and the other issue of velocity not being reset when a player hits the boundary.